### PR TITLE
Minor Changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+	id 'fabric-loom' version '0.6-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,9 @@
     "minecraft": "1.16.x"
   },
   "custom": {
-    "modmenu:parent": "litematica"
+    "modmenu": {
+      "parent": "carpet"
+    }
   }
 }
 


### PR DESCRIPTION
Stop log spam of `[main/WARN]: WARNING! Mod litematica_printer is only using deprecated 'modmenu:parent' custom value! This will be removed in 1.18 snapshots, so ask the author of this mod to support the new API.`